### PR TITLE
ensure no confirmed tx in mempool data

### DIFF
--- a/electrumx/server/mempool.py
+++ b/electrumx/server/mempool.py
@@ -365,14 +365,15 @@ class MemPool:
             await group.spawn(self._refresh_histogram(synchronized_event))
             await group.spawn(self._logging(synchronized_event))
 
-    async def balance_delta(self, hashX):
+    async def balance_delta(self, hashX, confirmed_txhash):
         '''Return the unconfirmed amount in the mempool for hashX.
 
         Can be positive or negative.
         '''
         value = 0
         if hashX in self.hashXs:
-            for hash in self.hashXs[hashX]:
+            unconfirmed = list(self.hashXs[hashX] - set(confirmed_txhash))
+            for hash in unconfirmed:
                 tx = self.txs[hash]
                 value -= sum(v for h168, v in tx.in_pairs if h168 == hashX)
                 value += sum(v for h168, v in tx.out_pairs if h168 == hashX)

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1129,7 +1129,8 @@ class ElectrumX(SessionBase):
     async def get_balance(self, hashX):
         utxos = await self.db.all_utxos(hashX)
         confirmed = sum(utxo.value for utxo in utxos)
-        unconfirmed = await self.mempool.balance_delta(hashX)
+        confirmed_txids = [utxo.tx_hash for utxo in utxos]
+        unconfirmed = await self.mempool.balance_delta(hashX, confirmed_txids)
         self.bump_cost(1.0 + len(utxos) / 50)
         return {'confirmed': confirmed, 'unconfirmed': unconfirmed}
 


### PR DESCRIPTION
Fixes issue where confirmed and unconfirmed balance overlaps and reports incorrectly.

![image](https://user-images.githubusercontent.com/35845239/172886216-89d285d6-0dd9-4b80-b313-0273e9d445d6.png)

ref: https://github.com/KomodoPlatform/atomicDEX-API/issues/1254#issuecomment-1100747092

